### PR TITLE
Fix an issue where multiple exports had the same name

### DIFF
--- a/components/typography/Accent/index.ts
+++ b/components/typography/Accent/index.ts
@@ -1,3 +1,2 @@
 export * from "./Accent";
-export * from "./styles";
 export * from "./types";


### PR DESCRIPTION
This change addresses a build issue where both the Accent main Component and the styled component called Accent were both called the same thing. This was causing a build issue when exported since there were two things with the same name. The change removes the export of the Styled Component since it is really only for internal use within the Component and external components should just use the main Accent Component.