### PR TITLE
Extract the logic for animating sections in and out to a Hook

### DIFF
--- a/components/layout/Section/Section.tsx
+++ b/components/layout/Section/Section.tsx
@@ -3,7 +3,7 @@ import * as S from "./styles";
 import { SectionProps } from "./types";
 import { Container } from "../Container";
 
-export const Section = forwardRef(function (
+export const Section = forwardRef(function Section(
   { children, size = "normal", ...containerProps }: SectionProps,
   ref: React.ForwardedRef<HTMLElement>
 ) {

--- a/components/layout/Section/Section.tsx
+++ b/components/layout/Section/Section.tsx
@@ -1,16 +1,15 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import * as S from "./styles";
 import { SectionProps } from "./types";
 import { Container } from "../Container";
 
-export function Section({
-  children,
-  size = "normal",
-  ...containerProps
-}: SectionProps) {
+export const Section = forwardRef(function (
+  { children, size = "normal", ...containerProps }: SectionProps,
+  ref: React.ForwardedRef<HTMLElement>
+) {
   return (
-    <S.Section size={size}>
+    <S.Section size={size} ref={ref}>
       <Container {...containerProps}>{children}</Container>
     </S.Section>
   );
-}
+});

--- a/components/layout/Section/styles.ts
+++ b/components/layout/Section/styles.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { StyledSectionProps } from "./types";
 
 export const Section = styled.section<StyledSectionProps>`
-  min-height: ${(props) => (props.size === "big" ? "100vh" : "75vh")};
+  min-height: ${(props) => (props.size === "big" ? "100vh" : "50vh")};
   display: flex;
   align-items: center;
   height: 100%;

--- a/components/layout/Section/types.ts
+++ b/components/layout/Section/types.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { ReactElement, RefObject } from "react";
 
 export interface SectionProps extends StyledSectionProps {
   children?: ReactElement | ReactElement[];

--- a/components/sections/Experience/Experience.tsx
+++ b/components/sections/Experience/Experience.tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement, useEffect, useRef, useState } from "react";
+import React, { ReactElement, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Accent } from "../../typography/Accent";
-import { Heading } from "../../typography/Headings";
 import { Section } from "../../layout/Section";
+import { Heading } from "../../typography/Headings";
+import { Accent } from "../../typography/Accent";
 import { Paragraph } from "../../typography/Paragraph";
 import * as S from "./styles";
 import { useAnimateOnScroll } from "../../../hooks/useAnimateOnScroll";
 
-export function About(): ReactElement {
+export function Experience(): ReactElement {
   const sectionRef = useRef<HTMLElement>(null);
   const showSection = useAnimateOnScroll(sectionRef);
 
@@ -27,7 +27,7 @@ export function About(): ReactElement {
             exit="exit"
           >
             <Heading variants={S.sectionVariants}>
-              <Accent>About me</Accent>
+              <Accent>Experience</Accent>
             </Heading>
             <Paragraph variants={S.sectionVariants}>
               Lorem ipsum, dolor sit amet consectetur adipisicing elit. Dolore

--- a/components/sections/Experience/index.ts
+++ b/components/sections/Experience/index.ts
@@ -1,0 +1,1 @@
+export * from "./Experience";

--- a/components/sections/Experience/styles.ts
+++ b/components/sections/Experience/styles.ts
@@ -1,0 +1,28 @@
+import { Transition, Variant } from "framer-motion";
+
+export const sectionVariants: Record<string, Variant> = {
+  entry: {
+    y: 30,
+    opacity: 0,
+    transition: {
+      when: "beforeChildren",
+      staggerChildren: 0.05,
+    },
+  },
+  visible: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      when: "beforeChildren",
+      staggerChildren: 0.05,
+    },
+  },
+  exit: {
+    y: -30,
+    opacity: 0,
+    transition: {
+      when: "beforeChildren",
+      staggerChildren: 0.05,
+    },
+  },
+};

--- a/hooks/useAnimateOnScroll/index.ts
+++ b/hooks/useAnimateOnScroll/index.ts
@@ -1,0 +1,1 @@
+export * from "./useAnimateOnScroll";

--- a/hooks/useAnimateOnScroll/useAnimateOnScroll.ts
+++ b/hooks/useAnimateOnScroll/useAnimateOnScroll.ts
@@ -1,0 +1,27 @@
+import { useEffect, RefObject, useState } from "react";
+import { useScrollDistance } from "../useScrollDistance";
+
+export function useAnimateOnScroll(
+  sectionRef: RefObject<HTMLElement>
+): boolean {
+  const [showSection, setShowSection] = useState(false);
+  const scrollDistance = useScrollDistance();
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && sectionRef.current) {
+      const offsetTop = sectionRef.current.offsetTop;
+      const { height } = sectionRef.current.getBoundingClientRect();
+
+      const topBoundary = offsetTop - height * 1.2;
+      const bottomBoundary = topBoundary + height * 1.4;
+
+      setShowSection(
+        scrollDistance > topBoundary && scrollDistance < bottomBoundary
+      );
+    } else {
+      setShowSection(false);
+    }
+  }, [scrollDistance]);
+
+  return showSection;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import { Head } from "../components/utilities/Head";
 import { Landing } from "../components/sections/Landing";
 import { Header } from "../components/layout/Header";
 import { About } from "../components/sections/About";
+import { Experience } from "../components/sections/Experience";
 import { Theme } from "../theme";
 
 const Home: NextPage = () => {
@@ -13,6 +14,7 @@ const Home: NextPage = () => {
       <Header />
       <Landing />
       <About />
+      <Experience />
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
Previously the logic that was used for animating in the About section was pretty hard-coded and worked for the About section but wouldn't really scale to the other sections since it used the overall window scroll distance rather than looking at how much the page has been scrolled relative to the section.

This change consolidates the logic and then extracts it to it's own hook which can be shared between sections without repeating code.