### PR TITLE
Remove Section Exit Animations

### DIFF
--- a/components/sections/About/About.tsx
+++ b/components/sections/About/About.tsx
@@ -26,7 +26,6 @@ export const About = forwardRef(function About(_, sectionRef: React.ForwardedRef
             variants={S.sectionVariants}
             initial="entry"
             animate="visible"
-            exit="exit"
           >
             <Heading variants={S.sectionVariants}>
               <Accent>About me</Accent>

--- a/components/sections/About/styles.ts
+++ b/components/sections/About/styles.ts
@@ -1,4 +1,4 @@
-import { Transition, Variant } from "framer-motion";
+import { Variant } from "framer-motion";
 
 export const sectionVariants: Record<string, Variant> = {
   entry: {
@@ -12,14 +12,6 @@ export const sectionVariants: Record<string, Variant> = {
   visible: {
     y: 0,
     opacity: 1,
-    transition: {
-      when: "beforeChildren",
-      staggerChildren: 0.05,
-    },
-  },
-  exit: {
-    y: -30,
-    opacity: 0,
     transition: {
       when: "beforeChildren",
       staggerChildren: 0.05,

--- a/components/sections/Contact/Contact.tsx
+++ b/components/sections/Contact/Contact.tsx
@@ -24,7 +24,6 @@ export const Contact = forwardRef(function About(_, sectionRef: React.ForwardedR
             variants={S.sectionVariants}
             initial="entry"
             animate="visible"
-            exit="exit"
           >
             <Heading variants={S.sectionVariants}>
               <Accent>Contact</Accent>

--- a/components/sections/Contact/styles.ts
+++ b/components/sections/Contact/styles.ts
@@ -1,4 +1,4 @@
-import { Transition, Variant } from "framer-motion";
+import { Variant } from "framer-motion";
 
 export const sectionVariants: Record<string, Variant> = {
   entry: {
@@ -12,14 +12,6 @@ export const sectionVariants: Record<string, Variant> = {
   visible: {
     y: 0,
     opacity: 1,
-    transition: {
-      when: "beforeChildren",
-      staggerChildren: 0.05,
-    },
-  },
-  exit: {
-    y: -30,
-    opacity: 0,
     transition: {
       when: "beforeChildren",
       staggerChildren: 0.05,

--- a/components/sections/Experience/Experience.tsx
+++ b/components/sections/Experience/Experience.tsx
@@ -24,7 +24,6 @@ export const Experience = forwardRef(function About(_, sectionRef: React.Forward
             variants={S.sectionVariants}
             initial="entry"
             animate="visible"
-            exit="exit"
           >
             <Heading variants={S.sectionVariants}>
               <Accent>Experience</Accent>

--- a/components/sections/Experience/styles.ts
+++ b/components/sections/Experience/styles.ts
@@ -1,4 +1,4 @@
-import { Transition, Variant } from "framer-motion";
+import { Variant } from "framer-motion";
 
 export const sectionVariants: Record<string, Variant> = {
   entry: {
@@ -12,14 +12,6 @@ export const sectionVariants: Record<string, Variant> = {
   visible: {
     y: 0,
     opacity: 1,
-    transition: {
-      when: "beforeChildren",
-      staggerChildren: 0.05,
-    },
-  },
-  exit: {
-    y: -30,
-    opacity: 0,
     transition: {
       when: "beforeChildren",
       staggerChildren: 0.05,

--- a/components/sections/Skills/Skills.tsx
+++ b/components/sections/Skills/Skills.tsx
@@ -24,7 +24,6 @@ export const Skills = forwardRef(function About(_, sectionRef: React.ForwardedRe
             variants={S.sectionVariants}
             initial="entry"
             animate="visible"
-            exit="exit"
           >
             <Heading variants={S.sectionVariants}>
               <Accent>Skills</Accent>

--- a/components/sections/Skills/styles.ts
+++ b/components/sections/Skills/styles.ts
@@ -1,4 +1,4 @@
-import { Transition, Variant } from "framer-motion";
+import { Variant } from "framer-motion";
 
 export const sectionVariants: Record<string, Variant> = {
   entry: {
@@ -12,14 +12,6 @@ export const sectionVariants: Record<string, Variant> = {
   visible: {
     y: 0,
     opacity: 1,
-    transition: {
-      when: "beforeChildren",
-      staggerChildren: 0.05,
-    },
-  },
-  exit: {
-    y: -30,
-    opacity: 0,
     transition: {
       when: "beforeChildren",
       staggerChildren: 0.05,

--- a/hooks/useAnimateOnScroll/useAnimateOnScroll.ts
+++ b/hooks/useAnimateOnScroll/useAnimateOnScroll.ts
@@ -2,9 +2,11 @@ import { useEffect, RefObject, useState } from "react";
 import { useScrollDistance } from "../useScrollDistance";
 
 export function useAnimateOnScroll(
-  sectionRef: RefObject<HTMLElement> 
+  sectionRef: RefObject<HTMLElement>
 ): boolean {
   const [showSection, setShowSection] = useState(false);
+  const [hasSectionAlreadyAppeared, setHasSectionAlreadyAppeared] =
+    useState(false);
   const scrollDistance = useScrollDistance();
 
   useEffect(() => {
@@ -13,15 +15,17 @@ export function useAnimateOnScroll(
       const { height } = sectionRef.current.getBoundingClientRect();
 
       const topBoundary = offsetTop - height * 1.2;
-      const bottomBoundary = topBoundary + height * 1.4;
 
-      setShowSection(
-        scrollDistance > topBoundary && scrollDistance < bottomBoundary
-      );
+      if (scrollDistance > topBoundary) {
+        setShowSection(true);
+        setHasSectionAlreadyAppeared(true);
+      } else {
+        setShowSection(false);
+      }
     } else {
       setShowSection(false);
     }
-  }, [scrollDistance]);
+  }, [scrollDistance, hasSectionAlreadyAppeared]);
 
-  return showSection;
+  return showSection || hasSectionAlreadyAppeared;
 }


### PR DESCRIPTION
Remove Section Exit Animations to reduce jarring and overwhelming animations when going past multiple sections quickly.